### PR TITLE
My ls a option

### DIFF
--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -82,7 +82,7 @@ argv_directories.each do |path|
             path = '.' if path.nil?
             Dir.foreach(path).sort
           else
-            Dir.glob('*', base: path).sort
+            Dir.glob('*', base: path)
           end
   ordered_files = organize_files(files, DISPLAY_MAX_LINE)
 

--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -25,7 +25,7 @@ def parse_argv_and_options(argv)
     end
   end
 
-  CommandlineArguments.new(options: argv_options, directories: argv_directories.sort, files: argv_files.sort, errors: argv_errors)
+  ParseResult.new(options: argv_options, directories: argv_directories.sort, files: argv_files.sort, errors: argv_errors)
 end
 
 def organize_files(file_names, display_max_line)
@@ -57,7 +57,7 @@ def display_directory(display_file_names_displayable)
 end
 
 DISPLAY_MAX_LINE = 3
-CommandlineArguments = Data.define(:options, :directories, :files, :errors)
+ParseResult = Data.define(:options, :directories, :files, :errors)
 commandline_arguments = parse_argv_and_options(ARGV)
 
 if !commandline_arguments.errors.empty?

--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -15,16 +15,26 @@ end
 def validate_file_or_directory_existence(argv)
   return argv if argv.nil?
 
-  exist_file_or_directory = []
+  exist_directory = []
+  exist_file = []
   argv.each do |x|
-    if !File.exist?(x)
-      puts "ls: '#{x}' にアクセスできません: そのようなファイルやディレクトリはありません。"
+    if File.directory?(x)
+      exist_directory << x
+    elsif File.file?(x)
+      exist_file << x
     else
-      exist_file_or_directory << x
+      puts "ls: '#{x}' にアクセスできません: そのようなファイルやディレクトリはありません。"
     end
   end
-  abort if exist_file_or_directory.last.nil?
-  exist_file_or_directory
+  # 引数にファイルを指定した場合、ディレクトリと区別して表示するためのロジック
+  if !exist_file.nil?
+    files = organize_files(exist_file, DISPLAY_MAX_LINE)
+    files = convert_to_displayable_array(files)
+    display_directory(files)
+    puts ''
+  end
+  abort if exist_directory.last.nil?
+  exist_directory
 end
 
 def organize_files(file_names, display_max_line)

--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -68,6 +68,7 @@ end
 
 # 引数にファイルを指定した場合、ディレクトリと区別して表示する
 if !argv_files.empty?
+  argv_files = argv_files.sort
   files = organize_files(argv_files, DISPLAY_MAX_LINE)
   files = convert_to_displayable_array(files)
   display_directory(files)

--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -7,7 +7,7 @@ def parse_option(argv)
   argv_files = []
   OptionParser.new do |opt|
     opt.on('-a') { |v| argv_option[:a] = v }
-    argv_files = opt.parse!(argv)
+    argv_files = opt.parse(argv)
   end
   [argv_option, argv_files]
 end

--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -2,6 +2,15 @@
 # frozen_string_literal: true
 
 require 'optparse'
+def parse_option(argv)
+  argv_option = {}
+  argv_files = []
+  OptionParser.new do |opt|
+    opt.on('-a') { |v| argv_option[:a] = v }
+    argv_files = opt.parse!(argv)
+  end
+  [argv_option, argv_files]
+end
 
 def validate_file_or_directory_existence(argv)
   return argv if argv.nil?
@@ -48,13 +57,18 @@ end
 
 DISPLAY_MAX_LINE = 3
 
-argv = ARGV.empty? ? [nil] : validate_file_or_directory_existence(ARGV)
+options, argv = parse_option(ARGV)
+
+argv = argv.empty? ? [nil] : validate_file_or_directory_existence(argv)
 
 argv.each do |path|
   puts "#{path}:" if argv.size > 1 || ARGV.size > 1
-
-  files = Dir.glob('*', base: path).sort
-
+  files = if options[:a]
+            path = '.' if path.nil?
+            Dir.foreach(path).sort
+          else
+            Dir.glob('*', base: path).sort
+          end
   ordered_files = organize_files(files, DISPLAY_MAX_LINE)
 
   displayable_files = convert_to_displayable_array(ordered_files)

--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -2,14 +2,14 @@
 # frozen_string_literal: true
 
 require 'optparse'
-def parse_option(argv)
-  argv_option = {}
+def parse_argv_and_options(argv)
+  argv_options = {}
   argv_files = []
   OptionParser.new do |opt|
-    opt.on('-a') { |v| argv_option[:a] = v }
+    opt.on('-a') { |v| argv_options[:a] = v }
     argv_files = opt.parse(argv)
   end
-  [argv_option, argv_files]
+  [argv_options, argv_files]
 end
 
 def validate_file_or_directory_existence(argv)
@@ -57,7 +57,7 @@ end
 
 DISPLAY_MAX_LINE = 3
 
-options, argv = parse_option(ARGV)
+options, argv = parse_argv_and_options(ARGV)
 
 argv = argv.empty? ? [nil] : validate_file_or_directory_existence(argv)
 

--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -25,7 +25,7 @@ def parse_argv_and_options(argv)
     end
   end
 
-  [argv_options, argv_directories.sort, argv_files.sort, argv_errors]
+  CommandlineArguments.new(options: argv_options, directories: argv_directories.sort, files: argv_files.sort, errors: argv_errors)
 end
 
 def organize_files(file_names, display_max_line)
@@ -57,28 +57,28 @@ def display_directory(display_file_names_displayable)
 end
 
 DISPLAY_MAX_LINE = 3
+CommandlineArguments = Data.define(:options, :directories, :files, :errors)
+commandline_arguments = parse_argv_and_options(ARGV)
 
-options, argv_directories, argv_files, argv_errors = parse_argv_and_options(ARGV)
-
-if !argv_errors.empty?
-  argv_errors.each do |error_argument|
+if !commandline_arguments.errors.empty?
+  commandline_arguments.errors.each do |error_argument|
     puts "ls: '#{error_argument}' にアクセスできません: そのようなファイルやディレクトリはありません。"
   end
 end
 
 # 引数にファイルを指定した場合、ディレクトリと区別して表示する
-if !argv_files.empty?
-  files = organize_files(argv_files, DISPLAY_MAX_LINE)
+if !commandline_arguments.files.empty?
+  files = organize_files(commandline_arguments.files, DISPLAY_MAX_LINE)
   files = convert_to_displayable_array(files)
   display_directory(files)
   puts ''
 end
 
-argv_directories.each do |path|
-  puts "#{path}:" if (argv_directories.size + argv_files.size) > 1
-  puts "#{path}:" if (argv_directories.size + argv_files.size) == 1 && !argv_errors.empty?
+commandline_arguments.directories.each do |path|
+  puts "#{path}:" if (commandline_arguments.directories.size + commandline_arguments.files.size) > 1
+  puts "#{path}:" if (commandline_arguments.directories.size + commandline_arguments.files.size) == 1 && !commandline_arguments.errors.empty?
 
-  files = if options[:a]
+  files = if commandline_arguments.options[:a]
             path = '.' if path.nil?
             Dir.foreach(path).sort
           else

--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -66,7 +66,7 @@ def display_directory(display_file_names_displayable)
 end
 
 DISPLAY_MAX_LINE = 3
-
+# オプションとコマンド引数を分離するロジック
 options, argv = parse_argv_and_options(ARGV)
 
 argv = argv.empty? ? [nil] : validate_file_or_directory_existence(argv)

--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -9,7 +9,7 @@ def validate_file_or_directory_existence(argv)
   exist_file_or_directory = []
   argv.each do |x|
     if !File.exist?(x)
-      puts "ls: #{x} にアクセスできません: そのようなファイルやディレクトリはありません。"
+      puts "ls: '#{x}' にアクセスできません: そのようなファイルやディレクトリはありません。"
     else
       exist_file_or_directory << x
     end
@@ -51,7 +51,7 @@ DISPLAY_MAX_LINE = 3
 argv = ARGV.empty? ? [nil] : validate_file_or_directory_existence(ARGV)
 
 argv.each do |path|
-  puts "#{path}:" if argv.size > 1 || ARGV.size != 1
+  puts "#{path}:" if argv.size > 1 || ARGV.size > 1
 
   files = Dir.glob('*', base: path).sort
 

--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -25,7 +25,7 @@ def parse_argv_and_options(argv)
     end
   end
 
-  [argv_options, argv_directories, argv_files, argv_errors]
+  [argv_options, argv_directories.sort, argv_files.sort, argv_errors]
 end
 
 def organize_files(file_names, display_max_line)
@@ -68,7 +68,6 @@ end
 
 # 引数にファイルを指定した場合、ディレクトリと区別して表示する
 if !argv_files.empty?
-  argv_files = argv_files.sort
   files = organize_files(argv_files, DISPLAY_MAX_LINE)
   files = convert_to_displayable_array(files)
   display_directory(files)


### PR DESCRIPTION
ls -a と同じ挙動を実装しました。
隠しファイルが表示できるようになっています。

注意
validate_file_or_directory_existenceメソッドに関して、ディレクトリではなくファイルを指定された場合の表示の形式が標準のlsコマンドと異なっていたので修正しました。